### PR TITLE
Add code coverage and coverall integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,7 @@ script:
   - npm run test
   - npm run e2e
   - npm run build -- --prod --base-href /
+
+after_success:
+  - npm run coverage
+  - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # Angular: How To
 [![Build Status](https://travis-ci.org/brunolm/angular-how-to.svg?branch=master)](https://travis-ci.org/brunolm/angular-how-to)
+[![Coverage Status](https://coveralls.io/repos/github/brunolm/angular-how-to/badge.svg?branch=master)](https://coveralls.io/github/brunolm/angular-how-to?branch=master)
 
 Each Pull Request will contain explanation and steps taken to complete a feature.
 
+## New project
+
 - [Create a new Angular project](https://github.com/brunolm/angular-how-to/pull/1)
+
+## Testing
+
 - [Add project on Travis CI](https://github.com/brunolm/angular-how-to/pull/2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1578,6 +1578,19 @@
         "require-from-string": "1.2.1"
       }
     },
+    "coveralls": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
+      "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.7.0",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.81.0"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
@@ -4347,6 +4360,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
     "less": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/less/-/less-2.7.3.tgz",
@@ -4487,6 +4506,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
       "dev": true
     },
     "log4js": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test --watch=false",
-    "test-watch": "ng test --watch=false",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "test-watch": "ng test --watch=false",
+    "coverage": "ng test --watch=false --code-coverage",
+    "coveralls": "coveralls < ./coverage/lcov.info"
   },
   "private": true,
   "dependencies": {
@@ -34,6 +36,7 @@
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
     "codelyzer": "~3.2.0",
+    "coveralls": "^3.0.0",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
     "karma": "~1.7.0",


### PR DESCRIPTION
## Coverage

- Add coverage script `ng test --watch=false --code-coverage` (https://github.com/angular/angular-cli/blob/master/docs/documentation/stories/code-coverage.md)

You can run code coverage and check the result locally:

```
npm run coverage
```

And then open `index.html` in the generated folder `coverage`

## Integration with coveralls:

- Install coveralls `npm i -D coveralls` (https://github.com/nickmerwin/node-coveralls)
  - Add coveralls script `coveralls < ./coverage/lcov.info`
- Setup `.travis.yml` to run `coverage` + `converalls` after successfully build
- Create coveralls account, link repo
  - After the build click the badge and copy the markdown code

---

Optional stuff

It is possible to run coveralls script locally, but you need to declare two variables: (https://github.com/nickmerwin/node-coveralls)

- `COVERALLS_SERVICE_NAME = "Travis"`
- `COVERALLS_REPO_TOKEN = "coveralls_token"`
- `npm run converalls`